### PR TITLE
Export feature slice instead of just reducer

### DIFF
--- a/template/src/features/counter/counterSlice.js
+++ b/template/src/features/counter/counterSlice.js
@@ -25,4 +25,4 @@ export const slice = createSlice({
 export const selectCount = state => state.counter.value;
 export const { increment, decrement, incrementByAmount } = slice.actions;
 
-export default slice.reducer;
+export default slice;

--- a/template/src/store.js
+++ b/template/src/store.js
@@ -1,8 +1,8 @@
-import { configureStore } from '@reduxjs/toolkit';
-import counterReducer from './features/counter/counterSlice';
+import { configureStore } from "@reduxjs/toolkit";
+import counterSlice from "./features/counter/counterSlice";
 
 export default configureStore({
   reducer: {
-    counter: counterReducer,
+    [counterSlice.name]: counterSlice.reducer
   },
 });


### PR DESCRIPTION
Suggestion:

This convention allows us to control state structure from within the feature itself, instead of the store. This is particularly useful because selectors must know how the state looks like in order to be more resistant to accidental errors (typos, etc...).