### PR TITLE
Extract Prettier config to fix lint script

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "es5",
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cra-template-redux",
   "version": "1.0.1",
   "scripts": {
-    "prettify": "prettier --trailing-comma es5 --single-quote --write './template/src/**/*.js'",
+    "prettify": "prettier --write './template/src/**/*.js'",
     "lint": "eslint './template/src/**/*.js'",
     "test": "jest"
   },


### PR DESCRIPTION
The lint script was failing because it was using the default Prettier config instead of ours.

This extracts the Prettier config so both Prettier and ESLint can use it, fixing the lint script.