### PR TITLE
Remove test suffix from lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cra-template-redux-test",
+  "name": "cra-template-redux",
   "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
This makes the name in `package.json` and `package-lock.json` consistent. I'm not sure if this affects publishing but it is showing up in the diffs whenever I `npm install` so we might as well commit it.

@BenLorantfy I noticed there are still `cra-template-redux-test` and `cra-template-redux-typescript-test` packages. Now that these packages are stable would you be okay with deprecating those packages? If we want to test experimental releases we should be able to use use npm tags with the main packages.