### PR TITLE
Use LF line endings for template files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Use LF line endings for template files
+/template/** text=auto eol=lf


### PR DESCRIPTION
Add a .gitattributes file that forces text files in the template directory to have LF line endings when checking out the repository. This ensures that the published template uses LF line endings even when published from a Windows machine.

To apply the new attributes it may be necessary to run the following commands:

    git rm --cached -r .
    git reset --hard

Source: https://stackoverflow.com/questions/9976986/force-lf-eol-in-git-repo-and-working-copy/34810209#34810209

Fixes #21