### PR TITLE
Consistent naming for slice reducers

### DIFF
--- a/template/src/features/counter/counterSlice.js
+++ b/template/src/features/counter/counterSlice.js
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { fetchCount } from './counterAPI';
 
+const name = "counter";
 const initialState = {
   value: 0,
   status: 'idle',
@@ -12,7 +13,7 @@ const initialState = {
 // code can then be executed and other actions can be dispatched. Thunks are
 // typically used to make async requests.
 export const incrementAsync = createAsyncThunk(
-  'counter/fetchCount',
+  `${name}/fetchCount`,
   async (amount) => {
     const response = await fetchCount(amount);
     // The value we return becomes the `fulfilled` action payload
@@ -21,7 +22,7 @@ export const incrementAsync = createAsyncThunk(
 );
 
 export const counterSlice = createSlice({
-  name: 'counter',
+  name,
   initialState,
   // The `reducers` field lets us define reducers and generate associated actions
   reducers: {


### PR DESCRIPTION
A minor change. I had to change the name twice to keep it consistent with all reducers. including `counter/fetchCount`. A name variable would be better.