### PR TITLE
add brackets in arguments

### DIFF
--- a/template/src/reportWebVitals.js
+++ b/template/src/reportWebVitals.js
@@ -1,4 +1,4 @@
-const reportWebVitals = onPerfEntry => {
+const reportWebVitals = (onPerfEntry) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);


### PR DESCRIPTION
when I run this tempalate using `react-scripts`, `eslint` also runs and expects brackets even in single function argument.
@timdorr @romseguy @Methuselah96 @msutkowski 